### PR TITLE
Minimal wrapper function for csdp

### DIFF
--- a/pkg/DESCRIPTION
+++ b/pkg/DESCRIPTION
@@ -9,3 +9,4 @@ Imports: methods
 Enhances: Matrix
 License: CPL-1.0
 URL: https://projects.coin-or.org/Csdp/
+BugReports: https://github.com/hcorrada/rcsdp/issues

--- a/pkg/NAMESPACE
+++ b/pkg/NAMESPACE
@@ -3,6 +3,7 @@ importFrom("methods", "as")
 importFrom("stats", "rnorm")
 
 export("csdp",
+       "csdp_minimal",
        "csdp.control",
        "readsdpa",
        "writesdpa",

--- a/pkg/R/Rcsdp.R
+++ b/pkg/R/Rcsdp.R
@@ -144,3 +144,19 @@ write.control.file <- function(control)
       cat(names(control)[i],"=",control[[i]],"\n",sep="",file=fileptr)
     close(fileptr)
   }
+
+csdp_minimal <- function(sum.block.sizes, nconstraints, nblocks, block.types, block.sizes, C, A, b) {
+  return(.Call(
+    "csdp",
+    as.integer(sum.block.sizes),
+    as.integer(nconstraints),
+    as.integer(nblocks),
+    as.integer(block.types),
+    as.integer(block.sizes),
+    C,
+    A,
+    b,
+    PACKAGE="Rcsdp"
+  ))
+}
+

--- a/pkg/man/csdp.Rd
+++ b/pkg/man/csdp.Rd
@@ -1,5 +1,6 @@
 \name{csdp}
 \alias{csdp}
+\alias{csdp_minimal}
 %- Also NEED an '\alias' for EACH other topic documented here.
 \title{Solve semidefinite program with CSDP}
 \description{
@@ -64,6 +65,14 @@ csdp(C, A, b, K,control=csdp.control())
 	the sizes given in argument \code{K}. It also checks that the
 	lengths of arguments \code{b} and \code{A}
 	are equal. It does not check for symmetry in the problem data.
+	
+	\code{csdp_minimal} is a minimal wrapper to the C code underlying \code{csdp}. It assumes that the arguments 
+	\code{sum.block.sizes}, \code{nconstraints}, \code{nblocks}, \code{block.types}, and \code{block.sizes}
+	are provided as if they were created by \code{Rcsdp:::prob.info} and that the arguments \code{C}, \code{A}, and 
+	\code{b} are provided as if they were created by \code{Rcsdp:::prepare.data}. This function may be useful when 
+	calling the csdp functionality iteratively and most of the optimization details stays the same. For example, when the
+	control file created by \code{Rcsdp:::write.control.file} stays the same across iterations, but it would be recreated
+	on each iteration by \code{csdp}.
 }
 \value{
   \item{X}{Optimal primal solution \eqn{X}. A list containing blocks in the


### PR DESCRIPTION
Added:
- a link for Bug reports to the DESCRIPTION file.
- a function `csdp_minimal`, which is a minimal wrapper function to the `csdp` C code
- some documentation for it `csdp_minimal`.

We briefly had email contact about this some months ago. 
Please let me know if you have any suggestions/ comments!
